### PR TITLE
Client Secret default in Sugar is ''

### DIFF
--- a/src/Client/Abstracts/AbstractSugarClient.php
+++ b/src/Client/Abstracts/AbstractSugarClient.php
@@ -166,7 +166,7 @@ abstract class AbstractSugarClient extends AbstractClient {
         if (!(empty($this->credentials['username'])||
             empty($this->credentials['password'])||
             empty($this->credentials['client_id'])||
-            empty($this->credentials['client_secret']))) {
+            !isset($this->credentials['client_secret']))) {
             $response = $this->oauth2Token()->execute($this->credentials)->getResponse();
             if ($response->getStatus() == '200') {
                 $this->setToken($response->getBody(FALSE));


### PR DESCRIPTION
Stupid bug. Since client_secret by default is blank, I can’t check if
its Empty, instead I have to just see if its not set.