### PR TITLE
Better Token Management

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "private": true,
+  "private": false,
   "name": "rest-php-client",
-  "description": "An SDK for interacting with Sugar's REST v10 API.",
-  "version": "1.1",
+  "version": "1.2",
+  "description": "An object oriented framework for interacting with Sugar 7's REST API.",
   "directories": {
     "test": "tests"
   },

--- a/src/Request/Abstracts/AbstractRequest.php
+++ b/src/Request/Abstracts/AbstractRequest.php
@@ -28,8 +28,7 @@ abstract class AbstractRequest implements RequestInterface {
         CURLOPT_HEADER => TRUE,
         CURLOPT_SSL_VERIFYPEER => FALSE,
         CURLOPT_RETURNTRANSFER => TRUE,
-        CURLOPT_FOLLOWLOCATION => FALSE,
-        CURLOPT_USERAGENT => 'SugarAPI-SDK-PHP'
+        CURLOPT_USERAGENT => 'Sugar-REST-PHP-Client'
     );
 
     /**

--- a/src/Response/Abstracts/AbstractResponse.php
+++ b/src/Response/Abstracts/AbstractResponse.php
@@ -54,7 +54,7 @@ abstract class AbstractResponse implements ResponseInterface {
 
     public function setCurlResponse($curlResponse) {
         $this->extractInfo();
-        if (!$this->error){
+        if ($this->error === FALSE){
             $this->extractResponse($curlResponse);
         }
     }

--- a/tests/Clients/AbstractSugarClientTest.php
+++ b/tests/Clients/AbstractSugarClientTest.php
@@ -185,17 +185,19 @@ class AbstractSugarClientTest extends \PHPUnit_Framework_TestCase {
      * @covers ::setToken
      * @covers ::getToken
      * @covers ::authenticated
+     * @covers ::expiredToken
      * @group abstractClient
      * @return SugarClientStub
      */
     public function testSetToken($Stub){
-
         static::$token->expires_in = 0;
+
         $Stub->setToken(static::$token);
         $this->assertEquals(static::$token,$Stub->getToken());
         $this->assertEquals(false,$Stub->authenticated());
 
         static::$token->expires_in = 3600;
+        unset(static::$token->expiration);
 
         $Stub->setToken(static::$token);
         $this->assertEquals(static::$token,$Stub->getToken());
@@ -278,6 +280,20 @@ class AbstractSugarClientTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
+     * @param SugarClientStub $Stub
+     * @depends testLogin
+     * @covers ::login
+     * @expectedException SugarAPI\SDK\Exception\Authentication\AuthenticationException
+     * @expectedExceptionMessageRegExp /Login Response/
+     * @group abstractClients
+     */
+    public function testLoginExceptionCurlError($Stub){
+        $Stub->setCredentials($this->credentials);
+        $Stub->setServer('test.foo.bar');
+        $Stub->login();
+    }
+
+    /**
      * @covers ::refreshToken
      * @group abstractClients
      * @return SugarClientStub
@@ -303,6 +319,21 @@ class AbstractSugarClientTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
+     * @param SugarClientStub $Stub
+     * @depends testRefreshToken
+     * @covers ::refreshToken
+     * @expectedException SugarAPI\SDK\Exception\Authentication\AuthenticationException
+     * @expectedExceptionMessageRegExp /Refresh Response/
+     * @group abstractClients
+     */
+    public function testRefreshExceptionCurlError($Stub){
+        $Stub->setCredentials($this->credentials);
+        $Stub->setToken(static::$token);
+        $Stub->setServer('test.foo.bar');
+        $Stub->refreshToken();
+    }
+
+    /**
      * @covers ::logout
      * @group abstractClients
      * @return SugarClientStub
@@ -323,6 +354,20 @@ class AbstractSugarClientTest extends \PHPUnit_Framework_TestCase {
      */
     public function testLogoutException($Stub){
         $Stub->setToken(static::$token);
+        $Stub->logout();
+    }
+
+    /**
+     * @param SugarClientStub $Stub
+     * @depends testLogout
+     * @covers ::logout
+     * @expectedException SugarAPI\SDK\Exception\Authentication\AuthenticationException
+     * @expectedExceptionMessageRegExp /Logout Response/
+     * @group abstractClients
+     */
+    public function testLogoutExceptionCurlError($Stub){
+        $Stub->setToken(static::$token);
+        $Stub->setServer('test.foo.bar');
         $Stub->logout();
     }
 


### PR DESCRIPTION
Added expiration and refresh_expiration to Set Token method, so that when Login is called actual Expiration time of the token is recorded for storage of token and retrieval of stored tokens.

Added expiration and refresh_expiration to Set Token method, so that
when Login is called actual Expiration time of the token is recorded
for storage of token and retrieval of stored tokens.

Made slight changes to Authentication Exceptions so that proper error messages were returned. Changed User Agent on Request.

After merge, please release v1.2

