### PR TITLE
Fixed FileResponse Bug with Filenames

### DIFF
--- a/src/Client/Abstracts/AbstractClient.php
+++ b/src/Client/Abstracts/AbstractClient.php
@@ -172,25 +172,26 @@ abstract class AbstractClient implements ClientInterface {
 
     /**
      * @inheritdoc
-     * @param \stdClass $token
+     * @param mixed $token
+     * @param string $identifier
      */
-    public static function storeToken($token, $client_id) {
-        static::$_STORED_TOKENS[$client_id] = $token;
+    public static function storeToken($token,$identifier) {
+        static::$_STORED_TOKENS[$identifier] = $token;
         return TRUE;
     }
 
     /**
      * @inheritdoc
      */
-    public static function getStoredToken($client_id) {
-        return (isset(static::$_STORED_TOKENS[$client_id])?static::$_STORED_TOKENS[$client_id]:NULL);
+    public static function getStoredToken($identifier) {
+        return (isset(static::$_STORED_TOKENS[$identifier])?static::$_STORED_TOKENS[$identifier]:NULL);
     }
 
     /**
      * @inheritdoc
      */
-    public static function removeStoredToken($client_id) {
-        unset(static::$_STORED_TOKENS[$client_id]);
+    public static function removeStoredToken($identifier) {
+        unset(static::$_STORED_TOKENS[$identifier]);
         return TRUE;
     }
 

--- a/src/Client/Abstracts/AbstractSugarClient.php
+++ b/src/Client/Abstracts/AbstractSugarClient.php
@@ -103,11 +103,9 @@ abstract class AbstractSugarClient extends AbstractClient {
             }
         }
         parent::setCredentials($this->credentials);
-        if (isset($this->credentials['client_id'])) {
-            $token = static::getStoredToken($this->credentials['client_id']);
-            if (!empty($token)) {
-                $this->setToken($token);
-            }
+        $token = static::getStoredToken($this->credentials);
+        if (!empty($token)) {
+            $this->setToken($token);
         }
         return $this;
     }
@@ -186,7 +184,7 @@ abstract class AbstractSugarClient extends AbstractClient {
             $response = $this->oauth2Token()->execute($this->credentials)->getResponse();
             if ($response->getStatus() == '200') {
                 $this->setToken($response->getBody(FALSE));
-                static::storeToken($this->token, $this->credentials['client_id']);
+                static::storeToken($this->token, $this->credentials);
                 return TRUE;
             } else {
                 if ($response->getError() === FALSE) {
@@ -242,9 +240,7 @@ abstract class AbstractSugarClient extends AbstractClient {
         if ($this->authenticated()){
             $response = $this->oauth2Logout()->execute()->getResponse();
             if ($response->getStatus()=='200'){
-                if (isset($this->credentials['client_id'])) {
-                    static::removeStoredToken($this->credentials['client_id']);
-                }
+                static::removeStoredToken($this->credentials);
                 return parent::logout();
             }else{
                 if ($response->getError() === FALSE) {
@@ -257,6 +253,62 @@ abstract class AbstractSugarClient extends AbstractClient {
             }
         }
         return FALSE;
+    }
+
+    /**
+     * @param \stdClass $token
+     * @param array $credentials
+     * @inheritdoc
+     */
+    public static function storeToken($token, $credentials) {
+        $client_id = $credentials['client_id'];
+        $platform = $credentials['platform'];
+        $username = $credentials['username'];
+        if (!isset(static::$_STORED_TOKENS[$client_id])){
+            static::$_STORED_TOKENS[$client_id] = array();
+            if (!isset(static::$_STORED_TOKENS[$client_id][$platform])){
+                static::$_STORED_TOKENS[$client_id][$platform] = array();
+            }
+        }
+        static::$_STORED_TOKENS[$client_id][$platform][$username] = $token;
+    }
+
+    /**
+     * @param array $credentials
+     * @inheritdoc
+     */
+    public static function getStoredToken($credentials) {
+        $storeData = parent::getStoredToken($credentials['client_id']);
+        if (!empty($storeData)){
+            $platform = $credentials['platform'];
+            if (isset($storeData[$platform])){
+                $username = $credentials['username'];
+                if (isset($storeData[$platform][$username])){
+                    return $storeData[$platform][$username];
+                }
+            }
+        }
+        return FALSE;
+    }
+
+    /**
+     * @param array $credentials
+     * @inheritdoc
+     */
+    public static function removeStoredToken($credentials) {
+        $client_id = $credentials['client_id'];
+        $platform = $credentials['platform'];
+        $username = $credentials['username'];
+        if (empty($platform) && empty($username)) {
+            return parent::removeStoredToken($client_id);
+        }else{
+            if (empty($username)){
+                unset(static::$_STORED_TOKENS[$client_id][$platform]);
+            }else{
+                unset(static::$_STORED_TOKENS[$client_id][$platform][$username]);
+            }
+        }
+        return TRUE;
     }
 
 }

--- a/src/Client/Abstracts/AbstractSugarClient.php
+++ b/src/Client/Abstracts/AbstractSugarClient.php
@@ -261,16 +261,22 @@ abstract class AbstractSugarClient extends AbstractClient {
      * @inheritdoc
      */
     public static function storeToken($token, $credentials) {
-        $client_id = $credentials['client_id'];
-        $platform = $credentials['platform'];
-        $username = $credentials['username'];
-        if (!isset(static::$_STORED_TOKENS[$client_id])){
-            static::$_STORED_TOKENS[$client_id] = array();
-            if (!isset(static::$_STORED_TOKENS[$client_id][$platform])){
-                static::$_STORED_TOKENS[$client_id][$platform] = array();
+        if (is_array($credentials)) {
+            if (isset($credentials['client_id'])&&isset($credentials['platform'])&&isset($credentials['username'])) {
+                $client_id = $credentials['client_id'];
+                $platform = $credentials['platform'];
+                $username = $credentials['username'];
+                if (!isset(static::$_STORED_TOKENS[$client_id])) {
+                    static::$_STORED_TOKENS[$client_id] = array();
+                    if (!isset(static::$_STORED_TOKENS[$client_id][$platform])) {
+                        static::$_STORED_TOKENS[$client_id][$platform] = array();
+                    }
+                }
+                static::$_STORED_TOKENS[$client_id][$platform][$username] = $token;
+                return TRUE;
             }
         }
-        static::$_STORED_TOKENS[$client_id][$platform][$username] = $token;
+        return FALSE;
     }
 
     /**
@@ -296,9 +302,12 @@ abstract class AbstractSugarClient extends AbstractClient {
      * @inheritdoc
      */
     public static function removeStoredToken($credentials) {
+        if (!is_array($credentials)||!isset($credentials['client_id'])){
+            return FALSE;
+        }
         $client_id = $credentials['client_id'];
-        $platform = $credentials['platform'];
-        $username = $credentials['username'];
+        $platform = isset($credentials['platform'])?$credentials['platform']:NULL;
+        $username = isset($credentials['username'])?$credentials['username']:NULL;
         if (empty($platform) && empty($username)) {
             return parent::removeStoredToken($client_id);
         }else{

--- a/src/Client/Interfaces/ClientInterface.php
+++ b/src/Client/Interfaces/ClientInterface.php
@@ -60,24 +60,24 @@ interface ClientInterface {
     /**
      * Store the SDK Clients authentication token
      * @param mixed $token
-     * @param string $client_id
+     * @param mixed $identifier
      * @return boolean
      */
-    public static function storeToken($token,$client_id);
+    public static function storeToken($token,$identifier);
 
     /**
      * Get an SDK Clients authentication Token from Storage
-     * @param $client_id
+     * @param mixed $identifier
      * @return mixed
      */
-    public static function getStoredToken($client_id);
+    public static function getStoredToken($identifier);
 
     /**
      * Remove the stored SDK Clients authentication token
-     * @param $client_id
+     * @param mixed $identifier
      * @return boolean
      */
-    public static function removeStoredToken($client_id);
+    public static function removeStoredToken($identifier);
 
     /**
      * Get the Token on the SDK Client

--- a/src/Endpoint/Abstracts/GET/AbstractGetFileEndpoint.php
+++ b/src/Endpoint/Abstracts/GET/AbstractGetFileEndpoint.php
@@ -23,7 +23,7 @@ abstract class AbstractGetFileEndpoint extends AbstractEndpoint {
         parent::__construct($url, $options);
     }
 
-    public function configureResponse(){
+    protected function configureResponse(){
         $this->Response->setDestinationPath($this->downloadDir);
         parent::configureResponse();
     }

--- a/src/Response/File.php
+++ b/src/Response/File.php
@@ -62,7 +62,8 @@ class File extends AbstractResponse {
         foreach (explode("\r\n", $this->headers) as $header)
         {
             if (strpos($header, 'filename')!==FALSE){
-                $this->setFileName(substr($header, (strpos($header, "\"")+1), -1));
+                $fileName = substr($header, (strpos($header, "=")+1), -1);
+                $this->setFileName($fileName);
             }
         }
     }
@@ -73,6 +74,8 @@ class File extends AbstractResponse {
      * @return self
      */
     public function setFileName($fileName){
+        $fileName = preg_replace("([^\w\s\d\-_~,;\[\]\(\).])", '', $fileName);
+        $fileName = preg_replace("([\.]{2,})", '', $fileName);
         $this->fileName = $fileName;
         return $this;
     }

--- a/src/Response/File.php
+++ b/src/Response/File.php
@@ -62,7 +62,7 @@ class File extends AbstractResponse {
         foreach (explode("\r\n", $this->headers) as $header)
         {
             if (strpos($header, 'filename')!==FALSE){
-                $fileName = substr($header, (strpos($header, "=")+1), -1);
+                $fileName = substr($header, (strpos($header, "=")+1));
                 $this->setFileName($fileName);
             }
         }

--- a/tests/Clients/AbstractSugarClientTest.php
+++ b/tests/Clients/AbstractSugarClientTest.php
@@ -222,7 +222,7 @@ class AbstractSugarClientTest extends \PHPUnit_Framework_TestCase {
      * @depends testSetToken
      * @covers ::getToken
      * @covers ::storeToken
-     * @coves ::removeStoredToken
+     * @covers ::removeStoredToken
      * @covers ::getStoredToken
      * @covers ::setCredentials
      * @group abstractClient

--- a/tests/Clients/AbstractSugarClientTest.php
+++ b/tests/Clients/AbstractSugarClientTest.php
@@ -282,6 +282,13 @@ class AbstractSugarClientTest extends \PHPUnit_Framework_TestCase {
         SugarClientStub::removeStoredToken(array('client_id' => 'sugar_abstract_test'));
         $token = SugarClientStub::getStoredToken($this->credentials);
         $this->assertEmpty($token);
+
+        $this->assertEquals(FALSE,SugarClientStub::storeToken(static::$token,'test'));
+        $this->assertEquals(FALSE,SugarClientStub::storeToken(static::$token,array('client_id' => 'test')));
+        $this->assertEquals(FALSE,SugarClientStub::storeToken(static::$token,array('client_id' => 'test','platform' => 'test')));
+        $this->assertEquals(FALSE,SugarClientStub::storeToken(static::$token,array('client_id' => 'test','username' => 'test')));
+        $this->assertEquals(FALSE,SugarClientStub::removeStoredToken('test'));
+        $this->assertEquals(FALSE,SugarClientStub::removeStoredToken(array('platform' => 'test')));
     }
 
     /**


### PR DESCRIPTION
Sugar’s response wasn’t exactly ‘standard’ when it came to the filename being attached to the header, so my original logic only worked for there File Responses. That being said, after working with the GitHub API using the Client, I tweaked the the way the Response gets the filename from the Headers so that it will work universally.