### PR TITLE
PHP 5.5+ File Upload Fixes - More Endpoints

### DIFF
--- a/examples/UploadFile.php
+++ b/examples/UploadFile.php
@@ -3,7 +3,7 @@
 require_once __DIR__.'/../vendor/autoload.php';
 
 try{
-    $SugarAPI = new \SugarAPI\SDK\SugarAPI('instances.this/Ent/7700/', array('username' => 'admin', 'password'=>'asdf'));
+    $SugarAPI = new \SugarAPI\SDK\SugarAPI('instances.this/Ent/7800/', array('username' => 'admin', 'password'=>'asdf'));
     $SugarAPI->login();
     $EP = $SugarAPI->createRecord('Notes')->execute(array('name' => 'Test Note'));
     $response = $EP->getResponse();

--- a/src/Client/Abstracts/AbstractSugarClient.php
+++ b/src/Client/Abstracts/AbstractSugarClient.php
@@ -8,6 +8,7 @@ namespace SugarAPI\SDK\Client\Abstracts;
 use SugarAPI\SDK\Exception\Authentication\AuthenticationException;
 use SugarAPI\SDK\Exception\SDKException;
 use SugarAPI\SDK\Helpers\Helpers;
+use SugarAPI\SDK\Endpoint\Interfaces\EPInterface;
 
 /**
  * The Abstract Client implementation for Sugar
@@ -17,27 +18,27 @@ use SugarAPI\SDK\Helpers\Helpers;
  * @method EPInterface getAttachment(string $module = '',string $record_id = '')
  * @method EPInterface getChangeLog(string $module = '',string $record_id = '')
  * @method EPInterface filterRelated(string $module = '')
- * @method EPInterface getRelated(string $module = '',
- *           string $record_id = '',
- *           string $relationship = '',
- *           string $related_id = '')
+ * @method EPInterface getRelated(string $module = '',string $record_id = '',string $relationship = '',string $related_id = '')
  * @method EPInterface me()
  * @method EPInterface search()
  * @method EPInterface oauth2Token()
  * @method EPInterface oauth2Refresh()
- * @method EPInterface createRecord()
- * @method EPInterface filterRecords()
- * @method EPInterface attachFile()
+ * @method EPInterface createRecord(string $module = '')
+ * @method EPInterface filterRecords(string $module = '')
+ * @method EPInterface attachFile(string $module = '',string $record_id = '')
  * @method EPInterface oauth2Logout()
- * @method EPInterface createRelated()
- * @method EPInterface linkRecords()
+ * @method EPInterface createRelated(string $module = '',string $record_id = '',string $relationship = '')
+ * @method @deprecated EPInterface linkRecords(string $module = '',string $record_id = '',string $relationship = '',string $related_id = '')
+ * @method EPInterface relateRecord(string $module = '',string $record_id = '',string $relationship = '',string $related_id = '')
+ * @method EPInterface massRelate(string $module = '',string $record_id = '')
  * @method EPInterface bulk()
- * @method EPInterface updateRecord()
- * @method EPInterface favorite()
- * @method EPInterface deleteRecord()
- * @method EPInterface unfavorite()
- * @method EPInterface deleteFile()
- * @method EPInterface unlinkRecords()
+ * @method EPInterface updateRecord(string $module = '',string $record_id = '')
+ * @method EPInterface updateRelated(string $module = '',string $record_id = '',string $relationship = '',string $related_id = '')
+ * @method EPInterface favorite(string $module = '',string $record_id = '')
+ * @method EPInterface deleteRecord(string $module = '',string $record_id = '')
+ * @method EPInterface unfavorite(string $module = '',string $record_id = '')
+ * @method EPInterface deleteFile(string $module = '',string $record_id = '')
+ * @method EPInterface unlinkRecords(string $module = '',string $record_id = '',string $relationship = '',string $related_id = '')
  */
 abstract class AbstractSugarClient extends AbstractClient
 {

--- a/src/Endpoint/POST/ModuleRecordFileField.php
+++ b/src/Endpoint/POST/ModuleRecordFileField.php
@@ -63,8 +63,12 @@ class ModuleRecordFileField extends AbstractPostFileEndpoint
      */
     protected function setFileFieldValue($value)
     {
-        if (strpos($value, '@') === false) {
-            $value = '@'.$value;
+        if (version_compare(PHP_VERSION, '5.5.0') >= 0){
+            $value = new \CURLFile($value);
+        } else {
+            if (strpos($value, '@') === false) {
+                $value = '@'.$value;
+            }
         }
         return $value;
     }

--- a/src/Endpoint/POST/ModuleRecordLink.php
+++ b/src/Endpoint/POST/ModuleRecordLink.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * ©[2016] SugarCRM Inc.  Licensed by SugarCRM under the Apache 2.0 license.
+ */
+
+namespace SugarAPI\SDK\Endpoint\POST;
+
+use SugarAPI\SDK\Endpoint\Abstracts\POST\AbstractPostEndpoint;
+
+class ModuleRecordLink extends AbstractPostEndpoint
+{
+    /**
+     * @inheritdoc
+     */
+    protected $_URL = '$module/$record/link';
+
+    /**
+     * @inheritdoc
+     */
+    protected $_REQUIRED_DATA = array(
+        'link_name' => NULL,
+        'ids' => NULL
+    );
+
+}

--- a/src/Endpoint/PUT/ModuleRecordLinkRecord.php
+++ b/src/Endpoint/PUT/ModuleRecordLinkRecord.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * ©[2016] SugarCRM Inc.  Licensed by SugarCRM under the Apache 2.0 license.
+ */
+
+namespace SugarAPI\SDK\Endpoint\PUT;
+
+use SugarAPI\SDK\Endpoint\Abstracts\PUT\AbstractPutEndpoint;
+
+class ModuleRecordLinkRecord extends AbstractPutEndpoint
+{
+    /**
+     * @inheritdoc
+     */
+    protected $_URL = '$module/$record/link/$relationship/$record';
+}

--- a/src/Helpers/registry.php
+++ b/src/Helpers/registry.php
@@ -25,6 +25,8 @@ $entryPoints = array(
     'oauth2Logout' => 'POST\\OAuth2Logout',
     'createRelated' => 'POST\\ModuleRecordRelationship',
     'linkRecords' => 'POST\\ModuleRecordLinkRecord',
+    'relateRecord' => 'POST\\ModuleRecordLinkRecord',
+    'massRelate' => 'POST\\ModuleRecordLink',
     'bulk' => 'POST\\Bulk',
 
     //PUT API Endpoints
@@ -32,6 +34,7 @@ $entryPoints = array(
     'favorite' => 'PUT\\ModuleRecordFavorite',
     'updateMe' => 'PUT\\Me',
     'updatePreferences' => 'PUT\\MePreferences',
+    'updateRelated' => 'PUT\\ModuleRecordLinkRecord',
 
     //DELETE API Endpoints
     'deleteRecord' => 'DELETE\\ModuleRecord',


### PR DESCRIPTION
Needed some Endpoints that weren’t there, such as MassRelate and Update
Related

Updated documentation on SugarClient

Added a check for PHP 5.5+, and CurlFile usage for File Uploads. Tested
it via Updated UploadFile example