### PR TITLE
Moved Default Endpoints to Registry

### DIFF
--- a/src/Endpoint/Provider/SugarEndpointProvider.php
+++ b/src/Endpoint/Provider/SugarEndpointProvider.php
@@ -5,11 +5,11 @@
 
 namespace Sugarcrm\REST\Endpoint\Provider;
 
-use MRussell\REST\Endpoint\Provider\AbstractEndpointProvider;
+use MRussell\REST\Endpoint\Provider\DefaultEndpointProvider;
 
-class SugarEndpointProvider extends AbstractEndpointProvider
+class SugarEndpointProvider extends DefaultEndpointProvider
 {
-    protected static $_DEFAULT_ENDPOINTS = array(
+    protected $registry = array(
         'module' => array(
             'class' => 'Sugarcrm\\REST\\Endpoint\\Module',
             'properties' => array()


### PR DESCRIPTION
Placing the Endpoints that already exist in the client in the Registry
saves processing on initial load, and allows for extended Providers to
use Default Endpoints static property for their own custom Endpoints.

Also uses 1.2.1 of PHP Rest Client library. 

Cut 2.0Beta3 release