### PR TITLE
Ading serverTime endpoint

### DIFF
--- a/src/Endpoint/GET/ServerTime.php
+++ b/src/Endpoint/GET/ServerTime.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * ©[2016] SugarCRM Inc.  Licensed by SugarCRM under the Apache 2.0 license.
+ */
+
+namespace SugarAPI\SDK\Endpoint\GET;
+
+use SugarAPI\SDK\Endpoint\Abstracts\GET\AbstractGetEndpoint;
+
+class ServerTime extends AbstractGetEndpoint
+{
+    /**
+     * @inheritdoc
+     */
+    protected $_URL = 'ping/whattimeisit';
+}

--- a/src/Helpers/registry.php
+++ b/src/Helpers/registry.php
@@ -15,6 +15,7 @@ $entryPoints = array(
     'me' => 'GET\\Me',
     'search' => 'GET\\Search',
     'preferences' => 'GET\\MePreferences',
+    'serverTime' => 'GET\\ServerTime',
 
     //POST API Endpoints
     'oauth2Token' => 'POST\\OAuth2Token',


### PR DESCRIPTION
New endpoint for whattimeisit sugarcrm endpoint(http://support.sugarcrm.com/Documentation/Sugar_Developer/Sugar_Developer_Guide_7.9/Integration/Web_Services/v10/Endpoints/pingwhattimeisit_GET/). It is usefull in same cases when we need sugarCRM server time, for example when syncing some records.