### PR TITLE
SUPP-875 Implementation of new endpoints: count & duplicateCheck

### DIFF
--- a/examples/DuplicateCheck.php
+++ b/examples/DuplicateCheck.php
@@ -1,0 +1,22 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+try {
+    $SugarAPI = new \SugarAPI\SDK\SugarAPI('instances.this/Pro/7621/', array('username' => 'admin','password'=>'asdf'));
+    $SugarAPI->login();
+    $EP = $SugarAPI->duplicateCheck('Accounts');
+    $data = array(
+        'name' => 'Airline'
+    );
+    $response = $EP->execute($data)->getResponse();
+    if ($response->getStatus()=='200') {
+        $recordList = $response->getBody(false);
+        $max=count($recordList->records);
+        echo $EP->getUrl() . " <br>\n";
+        echo "$max duplicate record(s) found. <br>\n";
+    }
+    $SugarAPI->logout();
+} catch (\SugarAPI\SDK\Exception\AuthenticationException $ex) {
+    print $ex->getMessage();
+}

--- a/examples/ModuleCount.php
+++ b/examples/ModuleCount.php
@@ -1,0 +1,21 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+try {
+    $SugarAPI = new \SugarAPI\SDK\SugarAPI('instances.this/Pro/7621/', array('username' => 'admin','password'=>'asdf'));
+    $SugarAPI->login();
+    foreach (['Accounts', 'Contacts'] as $module) {
+        $EP = $SugarAPI->count($module);
+        $response = $EP->execute()->getResponse();
+        if ($response->getStatus()=='200') {
+            $result = $response->getBody(false);
+            $count = $result->record_count;
+            echo $EP->getUrl() . " <br>\n";
+            echo "$count $module found. <br>\n";
+        }
+    }
+    $SugarAPI->logout();
+} catch (\SugarAPI\SDK\Exception\AuthenticationException $ex) {
+    print $ex->getMessage();
+}

--- a/src/Client/Abstracts/AbstractSugarClient.php
+++ b/src/Client/Abstracts/AbstractSugarClient.php
@@ -39,6 +39,7 @@ use SugarAPI\SDK\Endpoint\Interfaces\EPInterface;
  * @method EPInterface unfavorite(string $module = '',string $record_id = '')
  * @method EPInterface deleteFile(string $module = '',string $record_id = '')
  * @method EPInterface unlinkRecords(string $module = '',string $record_id = '',string $relationship = '',string $related_id = '')
+ * @method EPInterface duplicateCheck(string $module = '')
  */
 abstract class AbstractSugarClient extends AbstractClient
 {

--- a/src/Client/Abstracts/AbstractSugarClient.php
+++ b/src/Client/Abstracts/AbstractSugarClient.php
@@ -40,6 +40,7 @@ use SugarAPI\SDK\Endpoint\Interfaces\EPInterface;
  * @method EPInterface deleteFile(string $module = '',string $record_id = '')
  * @method EPInterface unlinkRecords(string $module = '',string $record_id = '',string $relationship = '',string $related_id = '')
  * @method EPInterface duplicateCheck(string $module = '')
+ * @method EPInterface count(string $module = '')
  */
 abstract class AbstractSugarClient extends AbstractClient
 {

--- a/src/Endpoint/GET/ModuleCount.php
+++ b/src/Endpoint/GET/ModuleCount.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * ©[2016] SugarCRM Inc.  Licensed by SugarCRM under the Apache 2.0 license.
+ */
+
+namespace SugarAPI\SDK\Endpoint\GET;
+
+use SugarAPI\SDK\Endpoint\Abstracts\GET\AbstractGetEndpoint;
+
+class ModuleCount extends AbstractGetEndpoint
+{
+    /**
+     * @inheritdoc
+     */
+    protected $_URL = '$module/count';
+}

--- a/src/Endpoint/POST/ModuleDuplicateCheck.php
+++ b/src/Endpoint/POST/ModuleDuplicateCheck.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * ©[2016] SugarCRM Inc.  Licensed by SugarCRM under the Apache 2.0 license.
+ */
+
+namespace SugarAPI\SDK\Endpoint\POST;
+
+use SugarAPI\SDK\Endpoint\Abstracts\POST\AbstractPostEndpoint;
+
+class ModuleDuplicateCheck extends AbstractPostEndpoint
+{
+    /**
+     * @inheritdoc
+     */
+    protected $_URL = '$module/duplicateCheck';
+}

--- a/src/Helpers/registry.php
+++ b/src/Helpers/registry.php
@@ -28,6 +28,7 @@ $entryPoints = array(
     'linkRecords' => 'POST\\ModuleRecordLinkRecord',
     'relateRecord' => 'POST\\ModuleRecordLinkRecord',
     'massRelate' => 'POST\\ModuleRecordLink',
+    'duplicateCheck' => 'POST\\ModuleDuplicateCheck',
     'bulk' => 'POST\\Bulk',
 
     //PUT API Endpoints

--- a/src/Helpers/registry.php
+++ b/src/Helpers/registry.php
@@ -16,6 +16,7 @@ $entryPoints = array(
     'search' => 'GET\\Search',
     'preferences' => 'GET\\MePreferences',
     'serverTime' => 'GET\\ServerTime',
+    'count' => 'GET\\ModuleCount',
 
     //POST API Endpoints
     'oauth2Token' => 'POST\\OAuth2Token',


### PR DESCRIPTION
providing 2 new endpoints:
- `/<module>/count` **GET** (solves issue https://github.com/sugarcrm/rest-php-client/issues/36)
- `/<module>/duplicateCheck` **POST**

also included:
- examples