### PR TITLE
Adding missing platform to the refreshToken function

### DIFF
--- a/src/Client/Abstracts/AbstractSugarClient.php
+++ b/src/Client/Abstracts/AbstractSugarClient.php
@@ -229,7 +229,8 @@ abstract class AbstractSugarClient extends AbstractClient
                 $refreshOptions = array(
                     'client_id' => $this->credentials['client_id'],
                     'client_secret' => $this->credentials['client_secret'],
-                    'refresh_token' => $this->token->refresh_token
+                    'refresh_token' => $this->token->refresh_token,
+                    'platform' => $this->credentials['platform']
                 );
                 $response = $this->oauth2Refresh()->execute($refreshOptions)->getResponse();
                 if ($response->getStatus() == '200') {


### PR DESCRIPTION
When you are not using the base platform and you need to refresh the token, you need to include the platform in the request. This solves that problem.