### PR TITLE
fix malformed date filters

### DIFF
--- a/src/Endpoint/Data/Filters/Expression/DateExpression.php
+++ b/src/Endpoint/Data/Filters/Expression/DateExpression.php
@@ -125,7 +125,7 @@ class DateExpression extends AbstractExpression
             return $this;
         }
         if (array_key_exists($name, $this->operators)) {
-            $args = array_replace($args, $arguments);
+            $args = array_merge($args, $arguments);
             $Operator = $this->operators[$name];
             $O = new $Operator($args);
             $this->filters[0] = $O;


### PR DESCRIPTION
This reverts a change made in [this commit](https://github.com/sugarcrm/rest-php-client/commit/fd9134049ed316b82dfcc1391e022edca6e71577#diff-b32a7e89e269f47a1deb286aadbacb4c85b0f4105a13e9ee1fd7e8696885516aR128) which seems to have broken a lot of the SI jobs on the datawarehouse. Specifically, when we're doing `$Collection->filter()->date('date_modified')->greaterThan($since);`  we're getting filters that end up looking like this: 
```
Collection Filter: Array
(
    [0] => Array
        (
            [2023-07-24T17:00:00-07:00] => Array
                (
                    [$gt] => 
                )

        )

)
```
instead of this:
```
Collection Filter: Array
(
    [0] => Array
        (
            [date_modified] => Array
                (
                    [$gt] => 2023-07-24T17:00:00-07:00
                )

        )

)
```

Open to doing this differently here as I'm not sure of the original reasoning for changing this to `array_replace`.